### PR TITLE
exec: modules: Use sort -u to get content from modalias

### DIFF
--- a/exec/early/modules
+++ b/exec/early/modules
@@ -6,7 +6,7 @@ MODULES=/etc/modules
 [ -e /proc/ksyms -o -e /proc/modules ] || exit 0
 
 # probe coldplugged modules
-find /sys -name 'modalias' -type f -exec cat '{}' + | sort -u | xargs modprobe -b -a 2>/dev/null
+find /sys -name 'modalias' -type f -exec sort -u '{}' + | sort -u | xargs modprobe -b -a 2>/dev/null
 
 # Exit if there's no modules file or there are no valid entries
 [ -r ${MODULES} ] && egrep -qv '^($|#)' ${MODULES} || exit 0


### PR DESCRIPTION
Some modalias pseudo-file may carry no newline at EOF. When reading its content with cat, its content will be undistinguishable with the next modalias file, causing necessary modules to be missed. Replace cat with sort -u, which ensures a newline is attached before EOF.