### PR TITLE
exec: modules: Drive modprobe with a loop instead of xargs

### DIFF
--- a/exec/early/modules
+++ b/exec/early/modules
@@ -6,7 +6,10 @@ MODULES=/etc/modules
 [ -e /proc/ksyms -o -e /proc/modules ] || exit 0
 
 # probe coldplugged modules
-find /sys -name 'modalias' -type f -exec sort -u '{}' + | sort -u | xargs modprobe -b -a 2>/dev/null
+find /sys -name 'modalias' -type f -exec sort -u '{}' + | sort -u |
+while read -r modalias; do
+  modprobe -q -b -a "$modalias"
+done
 
 # Exit if there's no modules file or there are no valid entries
 [ -r ${MODULES} ] && egrep -qv '^($|#)' ${MODULES} || exit 0


### PR DESCRIPTION
Single quote has special meanings for xargs, however, it might be included in modalias strings. For example, the dmi-id device, which starts to carry the product_family provided by firmware since Linux upstream commit 1afafbaf749d ("firmware/dmi: Include product_family info to modalias"). The xargs would break if the product_family string contains a single quote, e.g., ":pfaLet'snote/TOUGHBOOK:".